### PR TITLE
Update "How to Trade"

### DIFF
--- a/docs/how-to-trade.md
+++ b/docs/how-to-trade.md
@@ -7,8 +7,7 @@ sidebar_label: How to Trade
 ## Accessing the Ecosystem
 There are four ways to acquire the assets needed to trade on <a href="https://synthetix.exchange/" target="_blank" class="link">Synthetix Exchange</a>:
 - <a href="/docs/staking-snx-overview" class="link">Stake SNX</a> and mint sUSD to trade
-- Use Uniswap to exchange ETH for sETH to trade on Exchange
-- Use the utility on the left panel of the Exchange interface to exchange ETH for sUSD
+- Use Uniswap or DEX.AG to exchange ETH for sETH or sUSD to trade on Exchange
 - Use Ether Collateral to <a href="https://synthetix.exchange/loans" class="link" target="_blank">take out a sETH loan</a> on Synthetix Exchange
 
 ## Executing a Trade


### PR DESCRIPTION
There's no utility on the left panel on synthetix.exchange anymore. Only these cards:

<img width="1093" alt="Capture d’écran 2020-06-01 à 11 06 55" src="https://user-images.githubusercontent.com/8782666/83389066-40a51900-a3f8-11ea-87d7-01c3dc641bfd.png">

The first two both open the DEX.AG website.