### PR TITLE
Fix broken link in "Transferring SNX or Synths"

### DIFF
--- a/docs/transferring.md
+++ b/docs/transferring.md
@@ -10,7 +10,7 @@ There are some limitations to transferring the SNX tokens in your wallet. You ca
 
 ## Burning sUSD
 
-To unlock staked tokens, press `Burn` on <a href="https://beta.mintr.synthetix.io/" class="link" target="_blank">Mintr</a>. Press `View transferable SNX`. Here you'll be able to gauge how much SNX you can unlock for burning a given amount of sUSD. You'll need to burn enough sUSD to unlock *at least* the number of escrowed rewards tokens you have, before you'll be able to access transferable SNX. 
+To unlock staked tokens, press `Burn` on <a href="https://mintr.synthetix.io/" class="link" target="_blank">Mintr</a>. Press `View transferable SNX`. Here you'll be able to gauge how much SNX you can unlock for burning a given amount of sUSD. You'll need to burn enough sUSD to unlock *at least* the number of escrowed rewards tokens you have, before you'll be able to access transferable SNX. 
 
 ## Fee Reclamation
 


### PR DESCRIPTION
The correct link to the Mintr dapp seems to be **mintr.synthetix.io**, not **beta.mintr.synthetix.io**. The latter can't be accessed today, because of this certificate issue:

<img width="741" alt="Capture d’écran 2020-06-01 à 14 38 12" src="https://user-images.githubusercontent.com/8782666/83406022-6e00bf80-a416-11ea-8112-3a7a2c4209c3.png">